### PR TITLE
two api fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gunicorn validator.app:app
 
 ## API
 
+### Response Validation
 The main route for the app is /validate, which accepts a plaintext response (`response`) that will be checked.  It can also accept a number of optional arguments:
 
 - `uid` (e.g., '1000@1', default None): This is the uid for the question pertaining to the response. The uid is used to compute domain-specific and module-specific vocabulary to aid in the classification process.
@@ -49,7 +50,7 @@ Iff the version of the question specified is not available, any version of the s
 
 - `tag_numeric` (True, False or auto, default auto): Whether numerical values will be tagged (e.g., 123.7 is tagged with a special 'numeric_type_float' identifier). While there are certainly responses for which this would be helpful, a large amount of student garbage consists of random number pressing which limits the utility of this option. Auto enables a mode that only does numeric tag processing if the question this response pertains to (as fond via the uid above) requires a numeric answer.
 
-- `spelling_correction` (True, False or auto, default auto): Whether the app will attempt to correct misspellings. This is done by identifying unknown words in the response and seeing if a closely related known word can be substituted.  Currently, the app only attempts spelling correction on words of at least 5 characters in length and only considers candidate words that are within an edit distance of 2 from the misspelled word. When running in `auto` mode, the app will attempt to determine validity without spelling correction. Only if that is not valid, will it attempt to reasses validty with spelling correction.
+- `spelling_correction` (True, False or auto, default auto): Whether the app will attempt to correct misspellings. This is done by identifying unknown words in the response and seeing if a closely related known word can be substituted.  Currently, the app only attempts spelling correction on words of at least 5 characters in length and only considers candidate words that are within an edit distance of 2 from the misspelled word. When running in `auto` mode, the app will attempt to determine validity without spelling correction. Only if that is not valid, will it attempt to reassess validity with spelling correction.
 
 - `spell_correction_max` (integer, default 10): Limit spelling corrections applied to this number.
 
@@ -62,7 +63,7 @@ Here an example of how to call things using the Python requests library (assumin
 ```python
 import json
 import requests
-params = {'response': 'this is my answer to the question alkjsdfl',
+params = {'response': 'This is my answar to the macromolecules question nitrogenous awerawfsfs'
           'uid': '100@2',
           'remove_stopwords': True,
           'tag_numeric=True': False,
@@ -72,33 +73,140 @@ r = requests.get('http://127.0.0.1:5000/validate', params=params)
 print(json.dumps(r.json(), indent=2))
 {
   "bad_word_count": 1,
-  "common_word_count": 2,
-  "computation_time": 0.001367330551147461,
-  "domain_word_count": 0,
-  "inner_product": -1.6,
+  "common_word_count": 3,
+  "computation_time": 0.013212919235229492,
+  "domain_word_count": 1,
+  "inner_product": 1.5999999999999996,
   "innovation_word_count": 0,
-  "num_spelling_correction": 1,
-  "processed_response": "answer question nonsense_word",
+  "intercept": 1,
+  "lazy_math_evaluation": true,
+  "num_spelling_correction": 2,
+  "option_word_count": 0,
+  "processed_response": "answer macromolecules question nitrogenous nonsense_word",
   "remove_nonwords": true,
   "remove_stopwords": true,
-  "response": "this is my answer to the question alkjsdfl",
+  "response": "This is my answar to the macromolecules question nitrogenous awerawfsfs",
   "spelling_correction": true,
   "spelling_correction_used": true,
+  "stem_word_count": 0,
   "tag_numeric": "auto",
   "tag_numeric_input": "auto",
-  "uid_found": false,
-  "uid_used": null,
-  "valid": false
+  "uid_found": true,
+  "uid_used": "100@7",
+  "valid": true,
+  "version": "2.3.0"
 }
-
-
 ```
 
-## TODO:
+As you can see from these results, a number of features are taken into account
+when determining the potential validity of the students response: the words in
+the response itself, the words from the associated question (stem words) and
+its answers (option words), the words in the textbook associated with this
+assignment (domain words), and the words in the textbook whose first appearance
+is on the page associated with this question (innovation words). Various other
+features (presence or absence of math, spelling correction, stop word
+elimination, etc) are also applied. These tests depend on vocabularies being loaded
+for each exercise.
 
-While the app is fully functional, there are some other things that will need to be addressed:
+## Service APIs
 
+|Route|Response|Purpose|
+|-----|--------|-------|
+|`/ping`| `pong`| Determining that the validation service is operational.|
+|`/version` or `/rev.txt`| version string (i.e. 2.3.0)|What version of service is installed|
+|`/status`| json response (see below)| Detailed service info (extended version, start time) and datasets|
+
+
+Here is the `/status` response for a server started on Oct 1, with a clean install of version 2.3.0,
+and vocabularies for 5 books loaded:
+
+```json
+{
+  "datasets": {
+    "books": [
+      {
+        "name": "Biology 2e",
+        "vocabularies": [
+          "domain",
+          "innovation"
+        ],
+        "vuid": "8d50a0af-948b-4204-a71d-4826cba765b8@15.45"
+      },
+      {
+        "name": "College Physics for AP® Courses",
+        "vocabularies": [
+          "domain",
+          "innovation"
+        ],
+        "vuid": "8d04a686-d5e8-4798-a27d-c608e4d0e187@26.1"
+      },
+      {
+        "name": "College Physics with Courseware",
+        "vocabularies": [
+          "domain",
+          "innovation"
+        ],
+        "vuid": "405335a3-7cff-4df2-a9ad-29062a4af261@7.53"
+      },
+      {
+        "name": "Introduction to Sociology 2e",
+        "vocabularies": [
+          "domain",
+          "innovation"
+        ],
+        "vuid": "02040312-72c8-441e-a685-20e9333f3e1d@10.1"
+      },
+      {
+        "name": "Biology for AP® Courses",
+        "vocabularies": [
+          "domain",
+          "innovation"
+        ],
+        "vuid": "6c322e32-9fb0-4c4d-a1d7-20c95c5c7af2@18.4"
+      }
+    ]
+  },
+  "started": "Tue Oct  1 16:09:23 2019",
+  "version": {
+    "date": "2019-10-01T14:40:38-0500",
+    "dirty": false,
+    "error": null,
+    "full-revisionid": "ca00a4f816dabe4e97950b81bc8f178437b105e3",
+    "version": "2.3.0"
+  }
+}
+```
+The `datasets` at the top list the books that have their vocabularies loaded and available.
+
+### Dataset APIs
+
+The following routes all serve JSON formatted representations of the datasets used by the
+validator to make its validity determinations. Currently, book vocabularies are available.
+In the future, this will be expanded to the exercise vocabularies, as well as the weights used
+to combine the feature values (feature coefficients).
+
+|Route|Response
+|-----|--------
+/datasets | list of classes of datasets available
+/datasets/books| list of books
+/datasets/books/`<book-vuid>`| Data for a single book
+/datasets/books/`<book-vuid>`/vocabularies | list of vocabularies for a single book
+/datasets/books/`<book-vuid>`/vocabularies/domain | list of non-common words in the book
+/datasets/books/`<book-vuid>`/vocabularies/innovation | lists of novel words in each page of the book, by page
+/datasets/books/`<book-vuid>`/vocabularies/innovation/`<page-vuid>` | list of novel words for a specific page in the book
+
+### Processing APIs
+
+Route|Propose|Use
+---|---|---
+/import|load a book and associated exercises| POST a tutor ecosystem YAML file
+/train|find best-fit feature coefficents| POST a response training set
+
+
+#### TODO:
+
+- store feature coefficent sets, return IDs
+- additional data APIs for downloading exercise vocabularies and feature cofficient sets
 - Currently there is no security for this app (anything can call it).  I am not sure how this is usually handled in Tutor but it should not be too difficult to add an api key or similar security measures.
-- The Procfile will need to be changed a bit depending on how and where we wish to deploy
-- By far the largest element of the processing time for a response is devoted to spelling correction. While this does provide a very strong performance improvement for short responses, we may wish to automatically disable this in the case where the response is too long (larger than a paragraph).
 - Depending on UX, we may want to return more granular information about the response rather than a simple valid/non-valid label.  We can modify this easily enough as the need arises.
+

--- a/validator/app.py
+++ b/validator/app.py
@@ -490,12 +490,16 @@ def datasets_index():
     return jsonify(["books"])  # FIXME , "questions", "feature_coefficients"])
 
 
-@app.route("/datasets/books")
-def books_index():
+def _books_json():
     data = df_domain[["book_name", "vuid"]].rename({"book_name": "name"}, axis=1)
     data["vocabularies"] = [["domain", "innovation"]] * len(data)
     data_json = json.loads(data.to_json(orient="records"))
-    return jsonify(data_json)
+    return data_json
+
+
+@app.route("/datasets/books")
+def books_index():
+    return jsonify(_books_json())
 
 
 @app.route("/datasets/books/<vuid>")
@@ -549,12 +553,8 @@ def status():
     data = {"version": _version.get_versions(), "started": start_time}
 
     if "vuid" in df_domain.columns:
-        data["datasets"] = {
-            "books": [
-                {"name": b[1], "vuid": b[2]}
-                for b in df_domain[["book_name", "vuid"]].itertuples()
-            ]
-        }
+        data["datasets"] = {'books': _books_json()}
+
     return jsonify(data)
 
 

--- a/validator/app.py
+++ b/validator/app.py
@@ -550,7 +550,7 @@ def status():
 
     if "vuid" in df_domain.columns:
         data["datasets"] = {
-            "domains": [
+            "books": [
                 {"name": b[1], "vuid": b[2]}
                 for b in df_domain[["book_name", "vuid"]].itertuples()
             ]
@@ -558,6 +558,7 @@ def status():
     return jsonify(data)
 
 
+@app.route("/version")
 @app.route("/rev.txt")
 def simple_version():
     return __version__


### PR DESCRIPTION
correct status api for books. I added the `books` layer directly below `/datasets`, and moved  `domain` down below `vocabularies` under each book, but failed to update the `/status` page with that structure, so it still displayed '/datasets/domain` as a viable path. Also add top level `/version` as alias for `/rev.txt`