### PR TITLE
move qid lookup to app object, so it is updated by ecosystem import; …

### DIFF
--- a/validator/app.py
+++ b/validator/app.py
@@ -42,6 +42,10 @@ def create_app(**kwargs):
 
     app.df = df
 
+    app.qids = {}
+    for idcol in ("uid", "qid"):
+        app.qids[idcol] = set(df["questions"][idcol].values.tolist())
+
     app.register_blueprint(read_api.bp)
     app.register_blueprint(write_api.bp)
     app.register_blueprint(validate_api.bp)

--- a/validator/write_api.py
+++ b/validator/write_api.py
@@ -52,6 +52,10 @@ def update_fixed_data(df_domain_, df_innovation_, df_questions_):
     df["innovation"] = df["innovation"].append(df_innovation_, sort=False)
     df["questions"] = df["questions"].append(df_questions_, sort=False)
 
+    # Update qid sets - for shortcutting question lookup
+    for idcol in ("uid", "qid"):
+        current_app.qids[idcol] = set(df["questions"][idcol].values.tolist())
+
     # Finally, write the updated dataframes to disk and declare victory
     data_dir = current_app.config["DATA_DIR"]
     write_fixed_data(df["domain"], df["innovation"], df["questions"], data_dir)


### PR DESCRIPTION
…make question/domain fetch robust to incomplete data

Turns out the way question ids are linked to book ids is not particularly robust. Also, the id-sets used to short circuit question lookup were not being updated by ecosystem import.