### PR TITLE
Remove not, no, and does from the set of pre-filtered stopwords

### DIFF
--- a/validator/ml/stax_string_proc.py
+++ b/validator/ml/stax_string_proc.py
@@ -81,6 +81,9 @@ class StaxStringProc(object):
         # Set up the stopwords, remove 'a' due to math issues
         # TODO make stops come from file rather than nltk
         self.stops = set(stopwords.words("english"))
+        self.stops.remove("no")
+        self.stops.remove("not")
+        self.stops.remove("does")
 
         # Train the stax spelling corrector using all corpora
         train_text = ""

--- a/validator/ml/stax_string_proc.py
+++ b/validator/ml/stax_string_proc.py
@@ -84,6 +84,7 @@ class StaxStringProc(object):
         self.stops.remove("no")
         self.stops.remove("not")
         self.stops.remove("does")
+        self.stops.remove("it")
 
         # Train the stax spelling corrector using all corpora
         train_text = ""


### PR DESCRIPTION
I removed "no", "not", and "does" from the set of pre-filtered stopwords. This should allow most simple negative responses (e.g., "No, it does not") to pass through.