### PR TITLE
treat stimulus text as part of question text

### DIFF
--- a/validator/ecosystem_importer.py
+++ b/validator/ecosystem_importer.py
@@ -122,8 +122,10 @@ class EcosystemImporter(object):
         module_id_list = []
         for item in item_list:
             uid = item["uid"]
+            top_stimulus_text = self.format_cnxml(item.get("stimulus_html", ""))
             for question in item["questions"]:
                 stem_text = self.format_cnxml(question["stem_html"])
+                stimulus_text = self.format_cnxml(question.get("stimulus_html", ""))
                 answer_text = " ".join(
                     [
                         self.format_cnxml(answer["content_html"])
@@ -139,7 +141,11 @@ class EcosystemImporter(object):
                     target_module_id = list(target_module_id)[0]
                 module_id = target_module_id
                 uid_list.append(uid)
-                stem_list.append(stem_text)
+                stem_list.append(
+                    " ".join(
+                        [t for t in [top_stimulus_text, stem_text, stimulus_text] if t]
+                    )
+                )
                 answer_list.append(answer_text)
                 module_id_list.append(module_id)
         question_df = pd.DataFrame(


### PR DESCRIPTION
Exercises has a model that breaks up the question into stimulus and stem: the "background" part, and the actual question part. Up until now, validator only took into account the "stem" part, since most questions are written that way. Multipart questions in particular (such as https://exercises.openstax.org/api/exercises?q=uid:12118@4) tend to have a more significant stimulus block. This code combines it with the other question text parts.