### PR TITLE
avoid NaN for feature_weights_id for new book imports

### DIFF
--- a/validator/ecosystem_importer.py
+++ b/validator/ecosystem_importer.py
@@ -175,6 +175,7 @@ class EcosystemImporter(object):
 
         df_domain, df_innovation = self.get_book_content(archive_url, book_id)
         df_domain["book_name"] = book_title
+        df_domain["feature_weights_id"] = ""
 
         df_innovation["book_name"] = book_title
 


### PR DESCRIPTION
Fix an issue w/ book specific feature_weights_id not being set on new book import.